### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ import { baremuxPath } from "@mercuryworkshop/bare-mux/node";
 import { meteorPath } from "meteorproxy"
 import wisp from "wisp-server-node";
 import { createBareServer } from "@tomphttp/bare-server-node"
-//wahts the library i forgot
+import RateLimit from "express-rate-limit";
 import net from "node:net"
 import { hostname } from "node:os"
 const __filename = fileURLToPath(import.meta.url);
@@ -293,6 +293,15 @@ function startServer() {
     console.log(chalk.blue("Serving Meteor's files.."));
     console.log(chalk.green("Serving", chalk.yellow("Daylight's"), chalk.green("files")));
     console.log(chalk.green("All necessary files served. Setting up server."))
+
+    // set up rate limiter: maximum of 100 requests per 15 minutes
+    const limiter = RateLimit({
+        windowMs: 15 * 60 * 1000, // 15 minutes
+        max: 100, // max 100 requests per windowMs
+    });
+
+    // apply rate limiter to all requests
+    app.use(limiter);
 
     app.get("/", (req, res) => {
         res.sendFile(path.join(__dirname, "dist/index.html"));

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "vite-plugin-static-copy": "^1.0.6",
     "vite-plugin-vsharp": "^1.8.1",
     "wisp-server-node": "^1.1.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",


### PR DESCRIPTION
Potential fix for [https://github.com/NightProxy/Daylight/security/code-scanning/8](https://github.com/NightProxy/Daylight/security/code-scanning/8)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to all routes that serve files from the file system.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
